### PR TITLE
Feat: Image caching for the inference

### DIFF
--- a/components/ImagePreview.tsx
+++ b/components/ImagePreview.tsx
@@ -1,25 +1,21 @@
-/* eslint-disable @next/next/no-img-element */
 import { useEffect, useRef } from "react";
+import Image from "next/image";
 
 const ImagePreview: React.FC<{ url: string }> = ({ url }) => {
-  const imageRef = useRef<HTMLImageElement>(null);
+  const imageURL = useRef<string>(`/api/image?fileName=${url}`);
 
   useEffect(() => {
     if (!url) {
       console.debug("No image URL provided.");
       return;
     }
-    
-    if (imageRef.current) {
-      imageRef.current.src = `/api/image?fileName=${url}`;
-    }
+    imageURL.current = "/api/image?fileName=" + url;
   }, [url]);
 
   return url ? (
     <div className="relative h-[400px] w-[400px]">
-      <img
-        ref={imageRef}
-        src={`/api/image?fileName=${url}`} // Initial src
+      <Image
+        src={imageURL.current} // Initial src
         onError={(e) => { e.currentTarget.src = "/chest_placeholder.jpeg"; }}
         alt="Chest Xray images probably overlapped with heatmaps for identification."
         width={400}


### PR DESCRIPTION
Had to remove the next/image from previous version to due infinite requests. Maybe due to logic error or I was using the module incorrectly. Reimplemented ImagePreview.tsx